### PR TITLE
ip: add rfc7343 ORCHID v2 addresses

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1131,6 +1131,24 @@ binet.isRFC4843 = function isRFC4843(raw) {
 };
 
 /**
+ * Test whether the ip is RFC 7343.
+ * @param {Buffer} raw
+ * @returns {Boolean}
+ */
+
+binet.isRFC7343 = function isRFC7343(raw) {
+  assert(Buffer.isBuffer(raw));
+  assert(raw.length === 16);
+
+  if (raw[0] === 0x20 && raw[1] === 0x01
+      && raw[2] === 0x00 && (raw[3] & 0xf0) === 0x20) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
  * Test whether the ip is local.
  * @param {Buffer} raw
  * @returns {Boolean}
@@ -1220,6 +1238,9 @@ binet.isRoutable = function isRoutable(raw) {
     return false;
 
   if (binet.isRFC4843(raw))
+    return false;
+
+  if (binet.isRFC7343(raw))
     return false;
 
   if (binet.isLocal(raw))

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1123,6 +1123,24 @@ binet.isRFC4843 = function isRFC4843(raw) {
 };
 
 /**
+ * Test whether the ip is RFC 7343.
+ * @param {Buffer} raw
+ * @returns {Boolean}
+ */
+
+binet.isRFC7343 = function isRFC7343(raw) {
+  assert(Buffer.isBuffer(raw));
+  assert(raw.length === 16);
+
+  if (raw[0] === 0x20 && raw[1] === 0x01
+      && raw[2] === 0x00 && (raw[3] & 0xf0) === 0x20) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
  * Test whether the ip is local.
  * @param {Buffer} raw
  * @returns {Boolean}
@@ -1210,6 +1228,9 @@ binet.isRoutable = function isRoutable(raw) {
     return false;
 
   if (binet.isRFC4843(raw))
+    return false;
+
+  if (binet.isRFC7343(raw))
     return false;
 
   if (binet.isLocal(raw))

--- a/lib/ip.js
+++ b/lib/ip.js
@@ -1132,6 +1132,8 @@ binet.isRFC4843 = function isRFC4843(raw) {
 
 /**
  * Test whether the ip is RFC 7343.
+ * IPv6 ORCHIDv2 (2001:20::/28)
+ * https://tools.ietf.org/html/rfc7343
  * @param {Buffer} raw
  * @returns {Boolean}
  */

--- a/test/binet-test.js
+++ b/test/binet-test.js
@@ -95,6 +95,15 @@ describe('binet', function() {
     assert(!binet.isLocal(binet.decode('1.0.0.0')));
     assert(!binet.isLocal(binet.decode('::2')));
 
+    // isRFC7343 should return true for:
+    // - IPv6 ORCHIDv2 (2001:20::/28)
+    assert(binet.isRFC7343(binet.decode('2001:20::')));
+    assert(
+      binet.isRFC7343(binet.decode('2001:2f:ffff:ffff:ffff:ffff:ffff:ffff'))
+    );
+    assert(!binet.isRFC7343(binet.decode('2002:20::')));
+    assert(!binet.isRFC7343(binet.decode('0.0.0.0')));
+
     assert(binet.isRoutable(binet.decode('8.8.8.8')));
     assert(binet.isRoutable(binet.decode('2001::1')));
     assert(binet.isValid(binet.decode('127.0.0.1')));


### PR DESCRIPTION
> ORCHID v1 addresses were deprecated because they lacked "a mechanism for cryptographic algorithm
agility". This commit simply adds in a check for the new address format
defined in RFC 7343

See https://github.com/bcoin-org/binet/pull/3