### PR TITLE
ip: remove extra clause from rfc2544

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -942,9 +942,6 @@ binet.isRFC2544 = function isRFC2544(raw) {
   if (raw[12] === 198 && (raw[13] === 18 || raw[13] === 19))
     return true;
 
-  if (raw[12] === 169 && raw[13] === 254)
-    return true;
-
   return false;
 };
 


### PR DESCRIPTION
> I think this is an extra clause added from the below RFC.
> 
> From looking at Bitcoin core's check: https://github.com/bitcoin/bitcoin/blob/master/src/netaddress.cpp#L144
> 
> And the RFC spec here: https://tools.ietf.org/html/rfc2544

See https://github.com/bcoin-org/binet/pull/2